### PR TITLE
Remove Rythm and Groovy from bot scrobbling as the bots have shut down

### DIFF
--- a/docs/botscrobbling.md
+++ b/docs/botscrobbling.md
@@ -8,8 +8,6 @@ The bot will only scrobble songs it can find on Last.fm. The scrobbling works be
 
 ### Currently supported bots: 
 
-* Groovy
-* Rythm (Requires setting '[announcesongs](https://rythm.fm/docs/commands#settings)' to be enabled)
 * Hydra
 
 ### Requirements:


### PR DESCRIPTION
Both have since shut down music functionality:
- https://www.theverge.com/2021/8/24/22640024/youtube-discord-groovy-music-bot-closure
- https://www.theverge.com/2021/9/12/22669502/youtube-discord-rythm-music-bot-closure