### PR TITLE
Add missing premium server info, featured command options and improve admonitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 .DS_Store
+.idea

--- a/docs/commands/albums.md
+++ b/docs/commands/albums.md
@@ -20,7 +20,7 @@ Options:
 
     `.album Ventura Anderson .Paak`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want this command to also show the date you discovered an album and a graph of your listening history? [Get .fmbot supporter here.](../supporter.md)
     
 ---
@@ -42,7 +42,7 @@ Options:
     
     `.albumplays The Slow Rush`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to see a graph of your listening history for the album? [Get .fmbot supporter here.](../supporter.md)
     
 ---
@@ -245,7 +245,7 @@ Options:
 * Time period - `alltime`, `monthly`, `weekly` or last two months (e.g. `march`)
 * Sorting - `listeners` or `plays`
 * Artist - Filter by artist name
-* `rf` - Filter to specific roles ([Premium server](../premium-server.md))
+* `rf` - Filter to specific roles (✨ [Premium server](../premium-server.md) required)
 
 !!! note "Examples"
     `.sab`
@@ -284,6 +284,6 @@ Options:
     `.agaps xl`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     This command requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)
 

--- a/docs/commands/albums.md
+++ b/docs/commands/albums.md
@@ -11,6 +11,7 @@ Gets information about current album or the one you're searching for.
 Options:
 
 * Album - An album you want to search for. You can either use the built-in Last.fm search or separate the artist and album yourself using a | as separator.
+* Featured - Check for the currently featured album with `featured`
 
 !!! note "Examples"
     `.ab`
@@ -32,6 +33,7 @@ Options:
 
 * Album - An album you want to search for. You can either use the built-in Last.fm search or separate the artist and album yourself using a | as separator.
 * User - Select another user by mention, Discord ID or Last.fm username (`lfm:username`)
+* Featured - Check for the currently featured album with `featured`
 
 !!! note "Examples"
     `.abp`
@@ -135,6 +137,7 @@ Options:
 * Album - An album you want to search for. You can either use the built-in Last.fm search or separate the artist and album yourself using a | as separator.
 * User - Select another user by mention, Discord ID or Last.fm username (`lfm:username`)
 * Order by plays - Order tracks by playcount instead of album order (`plays`)
+* Featured - Check for the currently featured album with `featured`
 
 !!! note "Examples"
     `.abt`
@@ -154,6 +157,7 @@ Shows the cover for current album or the one you're searching for.
 Options:
 
 * Album - An album you want to search for. You can either use the built-in Last.fm search or separate the artist and album yourself using a | as separator.
+* Featured - Check for the currently featured album cover with `featured`
 
 !!! note "Examples"
     `.co`
@@ -174,7 +178,8 @@ Options:
 
 * Album - An album you want to search for. You can either use the built-in Last.fm search or separate the artist and album yourself using a | as separator.
 * Mode - Response mode. `embed`, `image` or `pages`
-* Nofilter - Disable server filters with `nofilter`/`nf`
+* Nofilter - Disable server filters with `nofilter`/`nf`* 
+* Featured - Check for the currently featured album with `featured`
 
 !!! note "Examples"
     `.wa`

--- a/docs/commands/artists.md
+++ b/docs/commands/artists.md
@@ -56,6 +56,7 @@ Options:
 * User - Select another user by mention, Discord ID or Last.fm username (`lfm:username`)
 * Random - Use `random`/`rnd` to view a random artist you've listened to
 * Noredirect - Disable Last.fm artist redirects with `noredirect`/`nr`
+* Featured - Check for the currently featured artist with `featured`
 
 !!! note "Examples"
     `.ap`
@@ -253,6 +254,7 @@ Options:
 * Random - Use `random`/`rnd` to view a random artist you've listened to
 * Noredirect - Disable Last.fm artist redirects with `noredirect`/`nr`
 * Nofilter - Disable server filters and crowns with `nofilter`/`nf`
+* Featured - Check for the currently featured artist with `featured`
 
 !!! note "Examples"
     `.w`
@@ -278,6 +280,7 @@ Options:
 * Mode - Response mode. `embed`, `image` or `pages`
 * Random - Use `random`/`rnd` to view a random artist you've listened to
 * Noredirect - Disable Last.fm artist redirects with `noredirect`/`nr`
+* Featured - Check for the currently featured artist with `featured`
 
 !!! note "Examples"
     `.fw`
@@ -306,6 +309,7 @@ Options:
 * Mode - Response mode. `embed`, `image` or `pages`
 * Random - Use `random`/`rnd` to view a random artist you've listened to
 * Noredirect - Disable Last.fm artist redirects with `noredirect`/`nr`
+* Featured - Check for the currently featured artist with `featured`
 
 !!! note "Examples"
     `.gw`

--- a/docs/commands/artists.md
+++ b/docs/commands/artists.md
@@ -23,7 +23,7 @@ Options:
 
     `.artist David Vunk`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want this command to also show the date you discovered an artist and a graph of your listening history? [Get .fmbot supporter here.](../supporter.md)
 
 
@@ -65,7 +65,7 @@ Options:
 
     `.artistplays Mall Grab`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to see a graph of your listening history for the artist? [Get .fmbot supporter here.](../supporter.md)
     
 ---
@@ -332,7 +332,7 @@ Options:
 
 * Time period - `alltime`, `monthly`, `weekly` or last two months (e.g. `march`)
 * Sorting - `listeners` or `plays`
-* `rf` - Filter to specific roles ([Premium server](../premium-server.md))
+* `rf` - Filter to specific roles (✨ [Premium server](../premium-server.md) required)
 
 !!! note "Examples"
     `.sa`
@@ -405,7 +405,7 @@ Time periods:
     `.discoveries monthly @user`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     This command requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -429,5 +429,5 @@ Options:
     `.gaps xl`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     This command requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)

--- a/docs/commands/crowns.md
+++ b/docs/commands/crowns.md
@@ -48,7 +48,9 @@ Options:
     `.crown tame impala @frikandel`
 
 !!! info "Crowns always go to the server's #1 listener"
-    The crown is awarded to whoever genuinely has the most plays in the server, so running `.crown` can hand the crown to a third member who is ahead of both you and the current holder. Every server crown setting still applies - [crown settings](../guildsettings/crownsettings.md) such as the minimum playcount, the activity threshold and crown blocks are all respected.
+    The crown is awarded to whoever genuinely has the most plays in the server, so running `.crown` can hand the crown to another member who is ahead of both you and the current holder. Every server crown setting still applies - [crown settings](../guildsettings/crownsettings.md) such as the minimum playcount, the activity threshold and crown blocks are all respected.
+
+    You can change this behavior with [`.crownroles`](../guildsettings/crownsettings.md#crownroles) (Premium server required)
 
 ---   
 ### .crownleaderboard (`.cwlb`)

--- a/docs/commands/crowns.md
+++ b/docs/commands/crowns.md
@@ -50,7 +50,7 @@ Options:
 !!! info "Crowns always go to the server's #1 listener"
     The crown is awarded to whoever genuinely has the most plays in the server, so running `.crown` can hand the crown to another member who is ahead of both you and the current holder. Every server crown setting still applies - [crown settings](../guildsettings/crownsettings.md) such as the minimum playcount, the activity threshold and crown blocks are all respected.
 
-    You can change this behavior with [`.crownroles`](../guildsettings/crownsettings.md#crownroles) (Premium server required)
+    You can change this behavior with [`.crownroles`](../guildsettings/crownsettings.md#crownroles) (✨ [Premium server](../premium-server.md) required)
 
 ---   
 ### .crownleaderboard (`.cwlb`)
@@ -63,7 +63,7 @@ Shows the users with the most crowns on your server.
     `.crownleaderboard`
 
     
-!!! info ""
+!!! tip
     Looking for automatic crowns, crown settings and ways to moderate crowns on your server? That's [available here](../guildsettings/crownsettings.md) in the server setting section.
 
 

--- a/docs/commands/discogs.md
+++ b/docs/commands/discogs.md
@@ -39,9 +39,10 @@ Options:
 
     `.collection cd`
 
-!!! info ""
+!!! info "Caching Limit"
     Only the last 100 items you've added to Discogs can be viewed and stored. 
-    
+
+!!! tip "⭐ Additional Supporter Feature" 
     Want to view your whole collection? [Get .fmbot supporter here.](../supporter.md)
 
 

--- a/docs/commands/featured.md
+++ b/docs/commands/featured.md
@@ -4,11 +4,13 @@ icon: lucide/sparkles
 
 # Featured commands     
 
-### .featured
+### .featured (.feat)
 
-Shows the user that is currently featured.
+Shows the user that is currently featured. Can also be used as an option on other commands. Shows the server featured
+if you have it set with [`.botbranding`](../guildsettings/index.md#botbranding).
 
-Anyone that is registered in fmbot can get featured, on one condition: They must have used .fmbot in the last day.
+Anyone that is registered in fmbot can get featured, on one condition: They must have used .fmbot in the last day. The last 20 users and albums from the past 14
+days are filtered out.
 
 Want to be notified when you're featured? Join [our server](https://discord.gg/JaHj26hHGk) and you'll get a ping.
 
@@ -33,9 +35,10 @@ If your top album doesn't have a picture, no worries. The bot will just grab the
 
 ---
 
-### .featuredlog
+### .featuredlog (.fl)
 
-Shows your or someone else their featured history.
+Shows your or someone else their featured history. Shows the server featured
+if you have it set with [`.botbranding`](../guildsettings/index.md#botbranding).
 
 Options:
 

--- a/docs/commands/featured.md
+++ b/docs/commands/featured.md
@@ -1,10 +1,10 @@
 ---
-icon: lucide/sparkles
+icon: lucide/mailbox
 ---
 
 # Featured commands     
 
-### .featured (.feat)
+### .featured (`.feat`)
 
 Shows the user that is currently featured. Can also be used as an option on other commands. Shows the server featured
 if you have it set with [`.botbranding`](../guildsettings/index.md#botbranding).
@@ -27,18 +27,19 @@ If your top album doesn't have a picture, no worries. The bot will just grab the
 !!! note "Examples"
     `.featured`
 
-        
-!!! info ""
+
+!!! tip "⭐ Additional Supporter Feature"
     Every first Sunday of each month is Supporter Sunday. On this day .fmbot picks featured from .fmbot supporters, as a thank you for supporting the bot.
     [Get .fmbot supporter here.](../supporter.md)
 
+!!! tip " ✨ Additional Premium Server Feature"
+    Want to have your very own featured cycle for only your server and its members? This is available with Premium Server and `.botbranding`. [Get premium server here.](../premium-server.md)
 
 ---
 
-### .featuredlog (.fl)
+### .featuredlog (`.fl`)
 
-Shows your or someone else their featured history. Shows the server featured
-if you have it set with [`.botbranding`](../guildsettings/index.md#botbranding).
+Shows your or someone else their featured history.
 
 Options:
 

--- a/docs/commands/friends.md
+++ b/docs/commands/friends.md
@@ -29,10 +29,10 @@ Select other users by mention, Discord ID or Last.fm username
     `.addfriends 356268235697553409`
 
 
-!!! info ""
-    Did you know there's also another way to add friends? Simply rightclick their profile > `Apps` > `Add Friend`
+!!! tip
+    Did you know there's also another way to add friends? Simply right-click their profile > `Apps` > `Add Friend`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to be able to add more friends (up to 240) and set close friends that always show up in `whoknows`? [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -52,7 +52,7 @@ Select other users by mention, Discord ID or Last.fm username
 
     `.removefriends 356268235697553409`
 
-!!! info ""
+!!! tip
     Did you know there's also another way to add friends? Simply rightclick their profile > `Apps` > `Remove Friend`
 
 ---

--- a/docs/commands/games.md
+++ b/docs/commands/games.md
@@ -25,10 +25,10 @@ Options:
 
     `.jumble stats`
 
-!!! info ""
-    Server staff and want to restrict jumble to specific channels? Use `.togglecommand`
+!!! tip
+    You're server staff and want to restrict jumble to specific channels? Use `.togglecommand`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to play unlimited jumbles every day? [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -54,8 +54,8 @@ Options:
 
     `.pixel stats`
 
-!!! info ""
-    Server staff and want to restrict pixel jumble to specific channels? Use `.togglecommand`
+!!! tip
+    You're server staff and want to restrict pixel jumble to specific channels? Use `.togglecommand`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to play unlimited pixel jumbles every day? [Get .fmbot supporter here.](../supporter.md)

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -56,7 +56,7 @@ Options:
 
     `.stats`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to see a graph of your listening history and a yearly overview on your profile? [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -113,7 +113,7 @@ Use the provided dropdowns to select and de-select which options you want.
 
     `/fmmode` (responds in-channel)
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Supporters can set custom accent colors, add up to 5 buttons and 10 footer options.
     [Get .fmbot supporter here.](../supporter.md)
 
@@ -139,7 +139,7 @@ You can also override this preference on every individual command. Simply add `i
 
 ---
 
-### .userreactions
+### .userreactions ⭐
 
 Sets automatic emoji reactions for every `.fm` and `featured` command you use.
 
@@ -148,10 +148,7 @@ To disable, simply use `.userreactions` without any emojis.
 Make sure the emojis you enable are in a server that .fmbot is also in.
 
 Max amount of emojis is 5. Please put a space between every emoji.
-
-!!! info ""
-    This setting is supporter only.
-    [Get .fmbot supporter here.](../supporter.md)
+    
 
 !!! note "Examples"
     `.userreactions :PagChomp: :PensiveBlob:`
@@ -161,6 +158,9 @@ Max amount of emojis is 5. Please put a space between every emoji.
     `.userreactions 😀 😯 :PensiveBlob:`
 
     `.userreactions`
+
+!!! info "⭐ Supporter Only Feature"
+    This setting is supporter only. [Get .fmbot supporter here.](../supporter.md)
 
 ---
 
@@ -188,15 +188,15 @@ Lets you set custom text command shortcuts. Your input is converted to the outpu
 
 Use `.shortcuts` to view and manage your shortcuts.
 
-!!! info ""
-    This feature is supporter only. Shortcuts are stored in-memory across all bot instances to keep command handling fast, so availability is limited.
-    [Get .fmbot supporter here.](../supporter.md)
-
 !!! note "Examples"
     `.shortcuts`
 
     A shortcut `yo` set to `fm textoneline` — typing `.yo` then runs `.fm textoneline`.
 
     A shortcut `progress` set to `chart 5x5 2025 skip` — typing `.progress` runs that chart.
+
+!!! info "⭐ Supporter Only Feature"
+    This feature is supporter only. Shortcuts are stored in-memory across all bot instances to keep command handling fast, so availability is limited.
+    [Get .fmbot supporter here.](../supporter.md)
 
     

--- a/docs/commands/misc.md
+++ b/docs/commands/misc.md
@@ -39,7 +39,7 @@ Options:
 
     `.judge french`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Supporters get access to higher quality compliments and roasts, generated with a better language model. [Get .fmbot supporter here.](../supporter.md)
 
 !!! note ""

--- a/docs/commands/plays.md
+++ b/docs/commands/plays.md
@@ -26,10 +26,10 @@ Options:
 
     `.fm this is a nice song`
 
-!!! info ""
-    Tip: You can click the embed title to go to the users Last.fm profile.
+!!! tip
+    You can click the embed title to go to the users Last.fm profile.
 
-!!! tip ""
+!!! tip
     If you want .fmbot to add reactions to this command, please see [`.serverreactions`](../guildsettings/index.md#serverreactions) and [`.userreactions`](./index.md#userreactions).
 
 ---
@@ -52,7 +52,7 @@ Options:
     `.recent moby`
     
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     For supporters this command expands to your full listening history. [Get .fmbot supporter here.](../supporter.md)
 
     
@@ -95,7 +95,7 @@ Available time periods: `weekly`, `monthly`, `quarterly`, `half`, `yearly`, `two
 
     `.plays monthly`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to see a graph of your listening history? [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -136,7 +136,7 @@ Options:
 
     `.streakhistory @user`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     The "Restore past streaks" button scans your lifetime listening history and adds streaks that were never saved. This requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -247,7 +247,7 @@ Options:
 
     `.year @frikandel`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Supporters get an extra page with Artist Discoveries and a monthly overview. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -273,7 +273,7 @@ Time periods:
 
     `.recap @frikandel`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Supporters get two extra pages with Discoveries and a listening time overview. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -294,7 +294,7 @@ Options:
     `.discoverydate @user`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     This command requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -315,5 +315,5 @@ Options:
     `.lastlistened @user`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     This command requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)

--- a/docs/commands/tracks.md
+++ b/docs/commands/tracks.md
@@ -21,7 +21,7 @@ Options:
 
     `.track Kaytranada You're The One`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want this command to also show the date you discovered a track and a graph of your listening history? [Get .fmbot supporter here.](../supporter.md)
     
 ---
@@ -42,7 +42,7 @@ Options:
 
     `.trackplays Infected Mushroom Can't Stop`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     Want to see a graph of your listening history for the track? [Get .fmbot supporter here.](../supporter.md)
 
     
@@ -84,7 +84,7 @@ Options:
     `.recent moby`
 
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     For supporters this command expands to your full listening history. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -221,7 +221,7 @@ Options:
 * Time period - `alltime`, `monthly`, `weekly` or last two months (e.g. `march`)
 * Sorting - `listeners` or `plays`
 * Artist - Filter by artist name
-* `rf` - Filter to specific roles ([Premium server](../premium-server.md))
+* `rf` - Filter to specific roles (✨ [Premium server](../premium-server.md) required)
 
 !!! note "Examples"
     `.st`
@@ -334,7 +334,7 @@ Options:
     `.tgaps xl`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     This command requires .fmbot to store your full listening history, which we only do for supporters. [Get .fmbot supporter here.](../supporter.md)
 
 ---
@@ -355,6 +355,6 @@ Options:
     `.lyrics around the world`
 
 
-!!! info ""
+!!! info "⭐ Supporter Only Feature"
     Viewing track lyrics in .fmbot is only available for .fmbot supporters. [Get .fmbot supporter here.](../supporter.md)
 

--- a/docs/commands/updating.md
+++ b/docs/commands/updating.md
@@ -30,10 +30,10 @@ This command updates your playcount cache in the bot. This works by fetching you
 
     `.update full`
 
-!!! info ""
+!!! tip "⭐ Additional Supporter Feature"
     If you want .fmbot to store more than just your top 4/5/6k artist/albums/tracks, check out [.fmbot supporter](../supporter.md)!
 
-!!! info ""
+!!! bug ""
     Having issues with the bot not picking up what you're playing on Spotify? Check out the [FAQ](../faq.md#commands-are-showing-the-wrong-songs-its-not-showing-what-i-listen-to-on-spotify).
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,7 +114,7 @@ icon: lucide/circle-help
 
     We are not affiliated with Last.fm. This bot only uses their API to show you and your friends their statistics.
 
-    If you have issues with Last.fm, we'd suggest you check out their [support forums](https://support.last.fm) or their [Discord server](https://discord.gg/swrVDCBZ8H).
+    If you have issues with Last.fm, we'd suggest you check out their [support forums](https://support.last.fm) or their [community Discord server](https://discord.gg/lastfm).
 
 ??? info "The bot is offline"
 
@@ -157,4 +157,4 @@ icon: lucide/circle-help
 
     Note that .fmbot and Last.fm are two separate things. .fmbot is the Discord bot, Last.fm is the website.
 
-    Need help with Last.fm? Check out their [support forums](https://support.last.fm) or their [Discord server](https://discord.gg/swrVDCBZ8H).
+    Need help with Last.fm? Check out their [support forums](https://support.last.fm) or their [community Discord server](https://discord.gg/swrVDCBZ8H).

--- a/docs/guildsettings/crownsettings.md
+++ b/docs/guildsettings/crownsettings.md
@@ -33,7 +33,7 @@ A user is counted as active once they use .fmbot.
 
 ---
 
-### .crownroles
+### .crownroles ✨
 
 Allows you to restrict crowns to members with specific roles. Only members who have at least one of the picked roles can claim or keep a crown.
 Currently held crowns remain if the role is removed from the user until they are claimed by someone else.
@@ -42,10 +42,11 @@ Members without one of these roles still appear in WhoKnows, they just can't ear
 
 Leave the role picker empty to turn the restriction off again, which lets everyone earn crowns.
 
-Requires [Premium server](../premium-server.md).
-
 !!! note "Examples"
     `.crownroles`
+
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)
 
 ---
 
@@ -122,6 +123,9 @@ Crown seeding again only updates automatically seeded crowns, not manually claim
 
 !!! note "Examples"
     `.crownseeder`
+
+!!! tip "✨ Additional Premium Server Feature"
+    Want your crowns to be seeded automatically on a schedule? This is available with Premium Server. [Get premium server here.](../premium-server.md)
     
 ---
 

--- a/docs/guildsettings/crownsettings.md
+++ b/docs/guildsettings/crownsettings.md
@@ -6,7 +6,7 @@ icon: lucide/crown
 
 You can change what users are able to gain crowns, configure other crown settings or completely disable crowns.
 
-These settings can only be changed by admins, users with the 'Ban Members' permission or .fmbot admins.
+These settings can only be changed by admins, users with the 'Ban Members' permission, users with the roles set in [`.botmanagementroles`](index.md#botmanagementroles), or .fmbot admins.
 
 
 ---
@@ -36,6 +36,7 @@ A user is counted as active once they use .fmbot.
 ### .crownroles
 
 Allows you to restrict crowns to members with specific roles. Only members who have at least one of the picked roles can claim or keep a crown.
+Currently held crowns remain if the role is removed from the user until they are claimed by someone else.
 
 Members without one of these roles still appear in WhoKnows, they just can't earn crowns.
 

--- a/docs/guildsettings/index.md
+++ b/docs/guildsettings/index.md
@@ -4,7 +4,7 @@ icon: lucide/settings
 
 # Server settings    
 
-Server settings can only be changed by admins, users with the 'Ban Members' permission or .fmbot admins.
+Server settings can only be changed by admins, users with the 'Ban Members' permission, users with the roles set in [`.botmanagementroles`](#botmanagementroles), or .fmbot admins.
 
 ---
 
@@ -76,7 +76,9 @@ Give .fmbot a custom look in your server. Three modes are available:
 - **Custom avatar** — Your own fixed logo or image, set by running `.botbranding` with an image attached
 - **Server featured** — The bot avatar follows a featured rotation based on the members of *your* server
 
-With server featured you can set how often a new pick rotates in, anywhere from every hour up to once a day, and optionally post each pick to a channel.
+With server featured you can set how often a new pick rotates in, anywhere from every hour up to once a day, and optionally post each pick to a channel. 
+It also respects the server activity threshold setting if enabled (user has to have messaged in the server in the last 5 days), 
+otherwise they have to have used .fmbot once in the last 5 days.
 
 Requires [Premium server](../premium-server.md).
 
@@ -128,3 +130,29 @@ Note that you can always mention the bot, this will work regardless of prefix.
     
     `!prefix`
 
+### .botmanagementroles
+
+Sets one or multiple roles who are allowed to configure .fmbot.
+These roles can change every setting except this one, block members and manage crowns. Only members with Administrator 
+or Ban Members can change this list.
+
+!!! note "Examples"
+    `.botmanagementroles`
+
+!!! info ""
+    This feature is available with Premium server. [Get Premium server here.](../premium-server.md)
+
+### .servershortcuts
+
+Set server-wide shortcuts (up to 10). Server shortcuts work for every member of this server, supporter or not.
+
+Some examples of what you can use as input and output:
+- `today` > `chart today 2x2`
+- `gamble` > `milestone random`
+- `gm` > `fm oneline`
+
+!!! note "Examples"
+`.servershortcuts`
+
+!!! info ""
+    This feature is available with Premium server. [Get Premium server here.](../premium-server.md)

--- a/docs/guildsettings/index.md
+++ b/docs/guildsettings/index.md
@@ -2,6 +2,7 @@
 icon: lucide/settings
 ---
 
+
 # Server settings    
 
 Server settings can only be changed by admins, users with the 'Ban Members' permission, users with the roles set in [`.botmanagementroles`](#botmanagementroles), or .fmbot admins.
@@ -50,7 +51,7 @@ Max amount of emojis is 3. Please put a space between every emoji.
     `.serverreactions`
 
 ---
-### .autoposter
+### .autoposter ✨
 
 Automatically posts your server's listening to a channel on a schedule. Configure up to 10 autoposts per server.
 
@@ -62,13 +63,14 @@ Each autopost can be a full **server recap** (top artists, albums and tracks, th
 - Posts are stored and shown as a billboard with movement versus the previous post, and a "Full list" button opens the full results
 - Post any autopost for the current period on demand with the "Post now" button
 
-Requires [Premium server](../premium-server.md).
-
 !!! note "Examples"
     `.autoposter`
 
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)
+
 ---   
-### .botbranding
+### .botbranding ✨
 
 Give .fmbot a custom look in your server. Three modes are available:
 
@@ -80,10 +82,11 @@ With server featured you can set how often a new pick rotates in, anywhere from 
 It also respects the server activity threshold setting if enabled (user has to have messaged in the server in the last 5 days), 
 otherwise they have to have used .fmbot once in the last 5 days.
 
-Requires [Premium server](../premium-server.md).
-
 !!! note "Examples"
     `.botbranding`
+
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)
 
 ---   
 ### .togglecommand
@@ -130,7 +133,7 @@ Note that you can always mention the bot, this will work regardless of prefix.
     
     `!prefix`
 
-### .botmanagementroles
+### .botmanagementroles ✨
 
 Sets one or multiple roles who are allowed to configure .fmbot.
 These roles can change every setting except this one, block members and manage crowns. Only members with Administrator 
@@ -139,10 +142,10 @@ or Ban Members can change this list.
 !!! note "Examples"
     `.botmanagementroles`
 
-!!! info ""
-    This feature is available with Premium server. [Get Premium server here.](../premium-server.md)
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)
 
-### .servershortcuts
+### .servershortcuts ✨
 
 Set server-wide shortcuts (up to 10). Server shortcuts work for every member of this server, supporter or not.
 
@@ -154,5 +157,5 @@ Some examples of what you can use as input and output:
 !!! note "Examples"
 `.servershortcuts`
 
-!!! info ""
-    This feature is available with Premium server. [Get Premium server here.](../premium-server.md)
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)

--- a/docs/guildsettings/whoknowsettings.md
+++ b/docs/guildsettings/whoknowsettings.md
@@ -6,13 +6,14 @@ icon: lucide/search
 
 You can change what users appear in the whoknows commands and other commands that use all server members
 
-These settings can only be changed by admins, users with the 'Ban Members' permission or .fmbot admins.
+These settings can only be changed by admins, users with the 'Ban Members' permission, users with the roles set in [`.botmanagementroles`](index.md#botmanagementroles), or .fmbot admins.
 
 ---
 
 ### .fmbotactivitythreshold
 
-Allows you to filter users from commands that have not been active in a certain amount of days.
+Allows you to filter users from commands that have not been active in a certain amount of days. Also prevents them from
+claiming crowns.
 
 A user is counted as active once they use .fmbot.
 
@@ -20,9 +21,24 @@ A user is counted as active once they use .fmbot.
     `.fmbotactivitythreshold`
 
 ---
+### .serveractivitythreshold
+
+Allows you to filter users from commands that have not been active in the server since a certain amount of days. 
+Also prevents them from claiming crowns.
+
+A user is counted as inactive if they haven't sent in the server in 30 days.
+
+Requires [Premium server](../premium-server.md).
+
+!!! note "Examples"
+`.serveractivitythreshold`
+
+---
 ### .block
 
 Blocks a user from appearing in whoknows and from being in any server-wide statistic.
+
+Also prevents them from claiming crowns.
 
 !!! note "Examples"
     `.block 748900688129687642`
@@ -32,7 +48,7 @@ Blocks a user from appearing in whoknows and from being in any server-wide stati
 ---
 ### .unblock
 
-Unblocks a user from appearing in whoknows and from being in any server-wide statistic.
+Unblocks a user from appearing in whoknows and from being in any server-wide statistic. 
 
 Also unblocks a user in case of any crown bans.
 
@@ -49,4 +65,29 @@ View all blocked members on your server.
 !!! note "Examples"
     `.blockedmembers`
 
+### .blockedmembers
 
+View all blocked members on your server.
+
+!!! note "Examples"
+    `.blockedmembers`
+
+---
+### .allowedroles
+
+Shows only users with these specific roles.
+
+Requires [Premium server](../premium-server.md).
+
+!!! note "Examples"
+    `.allowedroles`
+
+---
+### .blockedroles
+
+Always hides users with these specific roles.
+
+Requires [Premium server](../premium-server.md).
+
+!!! note "Examples"
+    `.blockedroles`

--- a/docs/guildsettings/whoknowsettings.md
+++ b/docs/guildsettings/whoknowsettings.md
@@ -21,17 +21,18 @@ A user is counted as active once they use .fmbot.
     `.fmbotactivitythreshold`
 
 ---
-### .serveractivitythreshold
+### .serveractivitythreshold ✨
 
 Allows you to filter users from commands that have not been active in the server since a certain amount of days. 
 Also prevents them from claiming crowns.
 
 A user is counted as inactive if they haven't sent in the server in 30 days.
 
-Requires [Premium server](../premium-server.md).
-
 !!! note "Examples"
 `.serveractivitythreshold`
+
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)
 
 ---
 ### .block
@@ -73,21 +74,23 @@ View all blocked members on your server.
     `.blockedmembers`
 
 ---
-### .allowedroles
+### .allowedroles ✨
 
 Shows only users with these specific roles.
-
-Requires [Premium server](../premium-server.md).
 
 !!! note "Examples"
     `.allowedroles`
 
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)
+
 ---
-### .blockedroles
+### .blockedroles ✨
 
 Always hides users with these specific roles.
 
-Requires [Premium server](../premium-server.md).
-
 !!! note "Examples"
     `.blockedroles`
+
+!!! info "✨ Premium Server Feature"
+    This feature is available with Premium server. [Get premium server here.](../premium-server.md)

--- a/docs/premium-server.md
+++ b/docs/premium-server.md
@@ -92,7 +92,7 @@ Create up to 10 text command shortcuts that work for every member in your server
 
 ### ⚙️ Filter inactive users serverwide
 
-- [`.serveractivitythreshold`](./guildsettings/whoknowsettings.md#serveractivitythreshold) — Filter out members from commands and crowns based on server activity
+- [`.serveractivitythreshold`](./guildsettings/whoknowsettings.md#serveractivitythreshold) — Filter out members from commands and crowns based on server activity instead of fmbot activity
 - [`.allowedroles`](./guildsettings/whoknowsettings.md#allowedroles) — Only show users with specific roles in commands
 - [`.blockedroles`](./guildsettings/whoknowsettings.md#blockedroles) — Hide users with specific roles from commands
 - [`.botmanagementroles`](./guildsettings/index.md#botmanagementroles) — Let trusted roles manage and configure .fmbot

--- a/docs/premium-server.md
+++ b/docs/premium-server.md
@@ -68,7 +68,7 @@ Set it up with the [`.autoposter`](guildsettings/index.md#autoposter) command.
 Give .fmbot a custom look in your server with the [`.botbranding`](guildsettings/index.md#botbranding) command. Three modes are available:
 
 - **Global featured** — The default look, where the bot avatar follows the global hourly featured
-- **Custom avatar** — Your own fixed logo or image, set by running `.botbranding` with an image attached
+- **Custom avatar** — Your own fixed logo or image, set by running [`.botbranding`](guildsettings/index.md#botbranding) with an image attached
 - **Server featured** — The bot avatar follows a featured rotation based on the members of *your* server
 
 With server featured you can set how often a new pick rotates in, anywhere from every hour up to once a day. The picks can also post automatically to a channel, just like the normal featured.
@@ -79,42 +79,44 @@ Every member gets 60 daily Jumble and Pixel Jumble games, up from 30. Individual
 
 ### 📜 Lyrics for everyone
 
-Every member can use the `.lyrics` command, no individual supporter subscription required.
+Every member can use the [`.lyrics`](commands/tracks.md#lyrics) command, no individual supporter subscription required.
 
 ### ⌨️ Server-wide shortcuts
 
-Create up to 10 text command shortcuts that work for every member in your server with `.servershortcuts`. Great for server-specific favorites like `.today` → `chart today 2x2`.
+Create up to 10 text command shortcuts that work for every member in your server with [`.servershortcuts`](guildsettings/index.md#servershortcuts). Great for server-specific favorites like `.today` → `chart today 2x2`.
 
-### 👑 Automatic crownseeder
+### 👑 More control over crowns
 
-The crownseeder generates and updates all WhoKnows crowns at once. With Premium server you can schedule it to run automatically daily, weekly or monthly, so crowns always stays up to date. 
+- **Automatic crownseeder**: The crownseeder generates and updates all WhoKnows crowns at once. With Premium server you can schedule it to run automatically daily, weekly or monthly, so crowns always stays up to date.
+- [`.crownroles`](./guildsettings/crownsettings.md#crownroles) — Only let users with specific roles earn crowns
 
 ### ⚙️ Filter inactive users serverwide
 
-- `.serveractivitythreshold` — Filter out members from commands based on server activity
-- `.allowedroles` — Only show users with specific roles in commands
-- `.blockedroles` — Hide users with specific roles from commands
-- `.crownroles` — Only let users with specific roles earn crowns
-- `.botmanagementroles` — Let trusted roles manage and configure .fmbot
+- [`.serveractivitythreshold`](./guildsettings/whoknowsettings.md#serveractivitythreshold) — Filter out members from commands and crowns based on server activity
+- [`.allowedroles`](./guildsettings/whoknowsettings.md#allowedroles) — Only show users with specific roles in commands
+- [`.blockedroles`](./guildsettings/whoknowsettings.md#blockedroles) — Hide users with specific roles from commands
+- [`.botmanagementroles`](./guildsettings/index.md#botmanagementroles) — Let trusted roles manage and configure .fmbot
 - Interactive role filtering with the `rf` option in WhoKnows and in server artist, album and track charts
 
 ---
 
 ## Premium server or supporter?
 
-|  | ⭐ Supporter | ✨ Premium server |
-|---|---|---|
-| Who is it for | You, everywhere | One server, everyone in it |
-| Where it works | All servers and DMs | The server it's purchased for |
-| Imports, expanded stats, discoveries | ✅ | ❌ |
-| Unlimited games | ✅ (you) | 60/day (everyone) |
-| Lyrics | ✅ (you) | ✅ (everyone) |
-| Shortcuts | ✅ (personal) | ✅ (server-wide) |
-| Automatic crownseeder | ❌ | ✅ |
+|                                       | ⭐ Supporter | ✨ Premium server |
+|---------------------------------------|---|---|
+| Who is it for                         | You, everywhere | One server, everyone in it |
+| Where it works                        | All servers and DMs | The server it's purchased for |
+| Imports, expanded stats, discoveries  | ✅ | ❌ |
+| Unlimited games                       | ✅ (you) | 60/day (everyone) |
+| Lyrics                                | ✅ (you) | ✅ (everyone) |
+| Shortcuts                             | ✅ (personal) | ✅ (server-wide) |
+| Automatic crownseeder                 | ❌ | ✅ |
+| Custom crown roles                    | ❌ | ✅ |
 | Server autoposter (recaps and charts) | ❌ | ✅ |
-| Custom avatar and server featured | ❌ | ✅ |
-| Role filters and activity threshold | ❌ | ✅ |
-| Get it with | `/getsupporter` | `/premiumserver` |
+| Custom avatar and server featured     | ❌ | ✅ |
+| Role filters and activity threshold   | ❌ | ✅ |
+| Custom bot manager roles              | ❌ | ✅ |
+| Get it with                           | `/getsupporter` | `/premiumserver` |
 
 Supporter is a personal subscription that follows you everywhere. Premium server upgrades one server for all of its members. They complement each other and neither includes the other.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ extra:
       link: https://twitter.com/fmbotDiscord
     - icon: fontawesome/brands/bluesky
       link: https://bsky.app/profile/fm.bot/
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/fmbot
   generator: false
 copyright: <a href="/privacy/">Privacy</a>  ·  <a href="/terms/">Terms</a>  ·  .fmbot is not affiliated with Last.fm 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,15 +83,15 @@ nav:
     - 'YouTube': 'commands/youtube.md'
     - 'Updating': 'commands/updating.md'
     - 'Miscellaneous': 'commands/misc.md'
+  - 'Server configuration':
+      - 'General': 'guildsettings/index.md'
+      - 'WhoKnows': 'guildsettings/whoknowsettings.md'
+      - 'Crowns': 'guildsettings/crownsettings.md'
+      - 'Webhooks': 'guildsettings/webhooks.md'
   - 'Spotify & Apple Music importing': 'importing.md'
+  - 'Music bot scrobbling': 'botscrobbling.md'
   - 'Get supporter': 'supporter.md'
   - 'Premium server': 'premium-server.md'
-  - 'Server configuration':
-    - 'General': 'guildsettings/index.md'
-    - 'WhoKnows': 'guildsettings/whoknowsettings.md'
-    - 'Crowns': 'guildsettings/crownsettings.md'
-    - 'Webhooks': 'guildsettings/webhooks.md'
-  - 'Music bot scrobbling': 'botscrobbling.md'
   - 'Join our server': https://discord.gg/fmbot
   - 'Add to server': https://discord.com/oauth2/authorize?client_id=356268235697553409&permissions=275415092288&scope=applications.commands%20bot
   - 'Add user app': https://discord.com/oauth2/authorize?client_id=356268235697553409&scope=applications.commands&integration_type=1


### PR DESCRIPTION
The first commit is adding missing information (like missing commands and the featured command option) or additional explanations to premium server features.

The second commit is more flavored, happy to adjust/revert depending on what you think:
- unified admonitions when command is fmbot supporter/premium server only
  
  <img width="710" height="130" alt="image" src="https://github.com/user-attachments/assets/4142cf8f-6bc0-4eb4-bf9f-feb68af98bf0" />

  <img width="727" height="98" alt="image" src="https://github.com/user-attachments/assets/8e15d9fd-6964-4b31-a13a-74d7bbe92145" />
- unified admonitions when command has additional fmbot supporter/premium server features
  <img width="697" height="126" alt="image" src="https://github.com/user-attachments/assets/c68f8aec-fb43-4bea-be59-d4dd4b38f794" />
  <img width="708" height="127" alt="image" src="https://github.com/user-attachments/assets/6c19b11e-2f92-4719-a46e-48ed866bfd85" />
- used ✨ to indicate premium server, just how ⭐ is used for fmbot supporter.
  <img width="730" height="393" alt="image" src="https://github.com/user-attachments/assets/0fc2de05-6124-488f-80f0-10d0d1b5606a" />

- added the "Tip" back to tip admonitions since I thought those are helpful context for those with attention span issues
  <img width="697" height="121" alt="image" src="https://github.com/user-attachments/assets/4e049bb8-62a9-4cc9-9d47-e1e21378227b" />
- changed the order of the items in the nav list because I think it makes more sense like this
  
  <img width="242" height="438" alt="image" src="https://github.com/user-attachments/assets/528217f0-9c7d-423e-8f82-2f398e4135de" />
   
  (ignore the missing server config icon, I think its zensical bug)


  



